### PR TITLE
Fix #68 - Na Sincronização add coluna com a quantidade de contas criadas no AD

### DIFF
--- a/app/Ldap/User.php
+++ b/app/Ldap/User.php
@@ -174,14 +174,17 @@ class User
 
     public static function getUsersGroup($grupo)
     {
+        $ldapusers = [];
         $group = Adldap::search()->groups()->find($grupo);
-        $ldapusers = Adldap::search()->users();
-        $ldapusers = $ldapusers->where('memberof', '=', $group->getDnBuilder()->get());
-        $ldapusers = $ldapusers->where('samaccountname','!=','Administrator');
-        $ldapusers = $ldapusers->where('samaccountname','!=','krbtgt');
-        $ldapusers = $ldapusers->where('samaccountname','!=','Guest');
-        $ldapusers = $ldapusers->sortBy('displayname', 'asc');
-        $ldapusers = $ldapusers->paginate(config('web-ldap-admin.registrosPorPagina'))->getResults();
+        if ($group != false) {
+            $ldapusers = Adldap::search()->users();        
+            $ldapusers = $ldapusers->where('memberof', '=', $group->getDnBuilder()->get());
+            $ldapusers = $ldapusers->where('samaccountname','!=','Administrator');
+            $ldapusers = $ldapusers->where('samaccountname','!=','krbtgt');
+            $ldapusers = $ldapusers->where('samaccountname','!=','Guest');
+            $ldapusers = $ldapusers->sortBy('displayname', 'asc');
+            $ldapusers = $ldapusers->paginate(config('web-ldap-admin.registrosPorPagina'))->getResults();
+        }
 
         return $ldapusers;
     }

--- a/resources/views/ldapusers/sync.blade.php
+++ b/resources/views/ldapusers/sync.blade.php
@@ -17,9 +17,8 @@
                     <tr>
                         <th>&nbsp;</th>
                         <th>Vínculo</th>
-                        <th>Replicado</th>
-                        {{-- <th>&nbsp;</th>
-                        <th>AD</th> --}}
+                        <th style="text-align: right;">Replicado</th>
+                        <th style="text-align: right;">AD</th>
                     </tr>
                     @foreach (Uspdev\Replicado\Pessoa::tiposVinculos(config('web-ldap-admin.replicado_unidade')) as $vinculo)
                     <tr>
@@ -27,8 +26,9 @@
                         <td>{{ $vinculo['tipvinext'] }}</td>
                         <td style="text-align: right;">
                             {{ count(Uspdev\Replicado\Pessoa::ativosVinculo($vinculo['tipvinext'], config('web-ldap-admin.replicado_unidade'))) }}</td>
-                        {{-- <td>>></td>
-                        <td style="text-align: right;">999</td> --}}
+                        <td style="text-align: right;">
+                            {{ count(App\Ldap\User::getUsersGroup($vinculo['tipvinext'])) }}
+                        </td>
                     </tr>
                     @endforeach                    
                 </table>


### PR DESCRIPTION
Fix #68 
:warning: 
Apareceram pequenas diferenças nos números da coluna AD, por exemplo:
1) Um Docente também pode ser Servidor
2) Um Estagiário também pode ser Aluno de Graduação
3) Um Servidor também pode ser Aluno de Graduação, de Pós-Graduação ou de Cultura e Extensão
* Corrigir: para a conta conste em todos os grupos em que a pessoa pertence *