### PR TITLE
Fix #112 - Solcitação de conta administrador

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,5 +79,7 @@ DESATIVAR_DESLIGADOS=false
 LOCAL_ADMIN_GROUP_LDAP=GRUPO_ADMIN_LOCAL
 NOT_REMOVE_GROUPS=GRUPO1,GRUPO2
 
-# Se for igual a 1 a opção de solicitar conta de administrador é exibida
-SOLICITA_CONTA_ADMIN=0
+# Se for igual a 0 a opção de solicitar conta de administrador não é exibida
+# Se for igual a 1 a opção de solicitar conta de administrador é exibida para todos
+# Se for igual a 2 a opção de solicitar conta de administrador é exibida somente para servidores
+SOLICITA_CONTA_ADMIN=2

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -4,7 +4,8 @@ namespace App\Providers;
 
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
-use Auth;
+use Illuminate\Support\Facades\Auth;
+use Uspdev\Replicado\Pessoa;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -28,14 +29,9 @@ class AuthServiceProvider extends ServiceProvider
 
         Gate::resource('ldapusers', 'App\Policies\LdapUserPolicy');
 
-        # logado 
-        Gate::define('logado', function ($user) { 
-            if($user){
-                return true;            
-            }
-            else {
-                return false;
-            }
+        // gate para servidor
+        Gate::define('servidor', function ($servidor) {
+            return in_array('SERVIDOR', Pessoa::obterSiglasVinculosAtivos(Auth::user()->codpes));
         });
     }
 }

--- a/app/Providers/ViewServiceProvider.php
+++ b/app/Providers/ViewServiceProvider.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Providers;
+
+use App\View\Composers\ProfileComposer;
+use Illuminate\Support\Facades\View;
+use Illuminate\Support\ServiceProvider;
+
+class ViewServiceProvider extends ServiceProvider
+{
+    /**
+     * Register any application services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        //
+    }
+
+    /**
+     * Bootstrap any application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        // Using class based composers...
+        View::composer('profile', ProfileComposer::class);
+
+        // Using closure based composers...
+        View::composer('dashboard', function ($view) {
+            //
+        });
+
+        // Menu dinâmico solicita conta admin
+        $menuContaAdmin = [
+            'text' => 'Solicitação de Conta de Administrador',
+            'url' => config('app.url') . '/solicita',
+            'can' => 'user',
+        ];
+
+        if (config('web-ldap-admin.solicitaContaAdmin') == 0) {
+            $menuContaAdmin = [];
+        } elseif (config('web-ldap-admin.solicitaContaAdmin') == 2) {
+            $menuContaAdmin['can'] = 'servidor';
+        }
+
+        \UspTheme::addMenu('solicitaContaAdmin', $menuContaAdmin);
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -160,6 +160,7 @@ return [
         // App\Providers\BroadcastServiceProvider::class,
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
+        App\Providers\ViewServiceProvider::class,
 
     ],
 

--- a/config/laravel-usp-theme.php
+++ b/config/laravel-usp-theme.php
@@ -1,22 +1,14 @@
 <?php
 
-if (getenv('SOLICITA_CONTA_ADMIN') == 1) {
-    $solicitaContaAdmin = [
-        'text' => 'Solicitação de Conta de Administrador',
-        'url' => config('app.url') . '/solicita',
-        'can' => 'logado',
-    ];
-} else {
-    $solicitaContaAdmin = [];
-}
-
 $menu = [
     [
         'text' => 'Minha Conta',
         'url' => config('app.url') . '/ldapusers/my',
-        'can' => 'logado',
+        'can' => 'user',
     ],
-    $solicitaContaAdmin,
+    [
+        'key' => 'solicitaContaAdmin', # menu dinâmico solicita conta admin
+    ],
     [
         'text' => 'Usuários Ldap',
         'url' => config('app.url') . '/ldapusers',
@@ -26,14 +18,16 @@ $menu = [
 
 $right_menu = [
     [
+        'key' => 'senhaunica-socialite',
+    ],
+    [
         'text' => '<i class="fas fa-cog"></i>',
         'title' => 'Configurações',
-        'target' => '_blank',
         'url' => config('app.url') . '/configs',
         'align' => 'right',
+        'can' => 'admin',
     ],
 ];
-
 
 return [
     'title' => config('app.name'),

--- a/config/senhaunica.php
+++ b/config/senhaunica.php
@@ -1,0 +1,47 @@
+<?php
+
+return [
+    // para rotas internas
+    'routes' => true, // usa rotas e controller internos
+
+    // coloque um prefixo em caso de colisão de rotas
+    // para todas as rotas internas da biblioteca (login, loginas, callback, logout e users).
+    'prefix' => '',
+
+    'middleware' => ['web'], // you probably want to include 'web' here
+    'session_key' => 'senhaunica-socialite', // chave da sessão. Troque em caso de colisão com outra variável de sessão.
+    'template' => 'laravel-usp-theme::master', // template a ser estendido para as views internas, deve possuir a section "content"
+
+    // define as rotas para o gerenciador de usuários interno, dentro de prefix
+    // se vazio, desabilita a rota de gerenciamento de usuários interna
+    'userRoutes' => 'users',
+
+    // usa as permissoes internas, padrão para v4.
+    // Se false, não usará permission ao efetuar login
+    'permission' => true,
+
+    // permite login somente de usuários já cadastrados na base local ou autorizados nos admins, gerentes ou users
+    'onlyLocalUsers' => false,
+
+    // se true, habilita botão para remover usuário (destroy)
+    'destroyUser' => true,
+
+    // se true, revoga as permissões do usuario se não estiver no env.
+    // quer dizer que as permissões serão gerenciadas todas a partir do env da aplicação.
+    'dropPermissions' => env('SENHAUNICA_DROP_PERMISSIONS', false),
+
+    // cadastre os admins separados por virgula
+    'admins' => array_map('trim', explode(',', env('SENHAUNICA_ADMINS', ''))),
+
+    // cadastre os gerentes separados por virgula
+    'gerentes' => array_map('trim', explode(',', env('SENHAUNICA_GERENTES', ''))),
+
+    // se quiser cadastre os usuários comuns autorizados. Relevante se onlyLocalUsers = true
+    'users' => array_map('trim', explode(',', env('SENHAUNICA_USERS', ''))),
+
+    'dev' => env('SENHAUNICA_DEV', 'no'),
+    'debug' => (bool) env('SENHAUNICA_DEBUG', false),
+    'callback_id' => env('SENHAUNICA_CALLBACK_ID'),
+
+    // SENHAUNICA_KEY e SENHAUNICA_SECRET são carregados em services.php da biblioteca
+];

--- a/config/web-ldap-admin.php
+++ b/config/web-ldap-admin.php
@@ -3,7 +3,7 @@
 return [
     # Footer theme
     'footer' => env('FOOTER', false),
-    
+
     # Unidades autorizadas
     'replicado_unidade' => env('REPLICADO_CODUNDCLG'),
 
@@ -16,6 +16,7 @@ return [
     'localAdminGroupLdap' => env('LOCAL_ADMIN_GROUP_LDAP', 'LOCAL_ADMIN'),
 
     'notRemoveGroups' => env('NOT_REMOVE_GROUPS', 'LOCAL_ADMIN,STI'),
-    
 
+    # 0 = ninguém, 1 = todos, 2 = servidores (funcionários e docentes)
+    'solicitaContaAdmin' => env('SOLICITA_CONTA_ADMIN', 0),
 ];


### PR DESCRIPTION
Fix #112 

Opcional ou só para servidores

Melhorando o menu
Retirando o gate logado e usando o gate padrão user
Usando menu dinâmico
Adicionando no menu de usuários em /users
Adicionando comentários para a variável de solicitação e conta admin
Criado o gate servidor
Chamando o menu dinâmico solicitação de conta admin
Adicionado o menu dinâmico solicitaContaAdmin
Habilitado o menu de usuários
Configurada a variável solicitaContaAdmin