### PR TITLE
Fix #122 - Parametrizado a unidade organizacional padrão

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,11 @@ LDAP_PASSWORD='sua-senha'
 LDAP_USE_SSL=true
 LDAP_USE_TLS=false
 
+# Unidade Organizacional Padrão onde os usuários serão criados
+# Se a Unidade Organizacional não existir, os usuários serão criados na raiz
+# Quando vazio será criado na raiz
+LDAP_OU_DEFAULT=
+
 # Replicado
 REPLICADO_HOST=
 REPLICADO_PORT=
@@ -90,3 +95,7 @@ SINC_LDAP_LOGIN=1
 
 # Tema do uspdev/laravel-usp-theme
 USP_THEME_SKIN=usp
+
+# O laravel-usp-theme permite que seja criado links
+# para outras aplicações da unidade
+# USP_THEME_SISTEMAS_1='{"text":"Pessoas","url":"https://pessoas"}'

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ yarn-error.log
 Dockerfile.custom
 # lando php.ini
 php.ini
+
+# vim bkp
+*.*~

--- a/app/Ldap/Group.php
+++ b/app/Ldap/Group.php
@@ -10,7 +10,7 @@ class Group
     public static function createOrUpdate(string $name)
     {
         $group = Adldap::search()->groups()->where('cn','=',$name)->first();
-        
+
         if (is_null($group) || $group == false) {
             $group = Adldap::make()->group();
 
@@ -18,10 +18,16 @@ class Group
             $dn = "CN={$name}," .  $group->getDnBuilder();
             $group->setDn($dn);
             $group->setAccountName(trim($name));
+            // save
             $group->save();
+
+            // Busca a OU padrão informada no .env
+            $ou = Adldap::search()->ous()->find(config('web-ldap-admin.ouDefault'));
+            // Move o grupo para a OU padrão somente se ela existir,
+            // do contrário deixa o grupo na raiz
+            $group->move($ou);
         }
 
-        // save
         return $group;
     }
 
@@ -59,7 +65,7 @@ class Group
         $groups = Adldap::search()->groups()->get();
         foreach($groups as $group) {
             if(empty(trim($group->getDescription()))){
-                array_push($r,$group->getName()); 
+                array_push($r,$group->getName());
             }
         }
         sort($r);

--- a/app/Ldap/User.php
+++ b/app/Ldap/User.php
@@ -27,6 +27,7 @@ class User
 
             // define DN para esse user
             $dn = "cn={$username}," .  $user->getDnBuilder();
+
             $user->setDn($dn);
 
             // Password
@@ -65,6 +66,12 @@ class User
 
         // Adiciona a um grupo
         LdapGroup::addMember($user, $groups);
+
+        // Busca a OU padrão informada no .env
+        $ou = Adldap::search()->ous()->find(config('web-ldap-admin.ouDefault'));
+        // Move o usuário para a OU padrão somente se ela existir,
+        // do contrário deixa o usuário na raiz
+        $user->move($ou);
 
         return $user;
     }
@@ -173,7 +180,7 @@ class User
         $user = Adldap::search()->where('cn', '=', $username)->whereEnabled()->first();
         if(!is_null($user)){
             $user->setPassword($password);
-            
+
             try {
                 $user->save();
             } catch(\ErrorException $e) {
@@ -181,7 +188,7 @@ class User
             }
         }
         return($result);
-    }    
+    }
 
     public static function getUsersGroup($grupo)
     {

--- a/config/laravel-usp-theme.php
+++ b/config/laravel-usp-theme.php
@@ -2,7 +2,7 @@
 
 $menu = [
     [
-        'text' => 'Minha Conta',
+        'text' => 'Minha Conta (trocar senha da rede)',
         'url' => config('app.url') . '/ldapusers/my',
         'can' => 'user',
     ],
@@ -17,11 +17,11 @@ $menu = [
 ];
 
 $right_menu = [
-    [
+    /*[
         'key' => 'senhaunica-socialite',
-    ],
+    ],*/
     [
-        'text' => '<i class="fas fa-cog"></i>',
+        'text' => '<i class="fas fa-cog"></i> Sincronizar ' . env('LDAP_OU_DEFAULT'),
         'title' => 'Configurações',
         'url' => config('app.url') . '/configs',
         'align' => 'right',

--- a/config/web-ldap-admin.php
+++ b/config/web-ldap-admin.php
@@ -19,7 +19,10 @@ return [
 
     # 0 = ninguém, 1 = todos, 2 = servidores (funcionários e docentes)
     'solicitaContaAdmin' => env('SOLICITA_CONTA_ADMIN', 0),
-    
+
     # 0 = não sincroniza durante login, 1 = sincroniza durante login
     'sincLdapLogin' => env('SINC_LDAP_LOGIN', 1),
+
+    # Unidade Organizacional padrão
+    'ouDefault' => env('LDAP_OU_DEFAULT', ''),
 ];

--- a/resources/views/ldapusers/sync.blade.php
+++ b/resources/views/ldapusers/sync.blade.php
@@ -10,7 +10,7 @@
     @include('alerts')
 
         <div class="col-md-6">
-                       
+
             <form method="post" action="{{ url('/ldapusers/sync') }}">
                 {{ csrf_field() }}
                 <table class="table table-striped">
@@ -18,21 +18,29 @@
                         <th>&nbsp;</th>
                         <th>Vínculo</th>
                         <th style="text-align: right;">Replicado</th>
-                        <th style="text-align: right;">AD</th>
-                    </tr>
-
+                        <th style="text-align: right;">{{ config('web-ldap-admin.ouDefault') }}</th>
+		            </tr>
                     @foreach (Uspdev\Replicado\Pessoa::tiposVinculos(config('web-ldap-admin.replicado_unidade')) as $vinculo)
+		    	        @php
+                            $countReplicado = Uspdev\Replicado\Pessoa::ativosVinculo($vinculo['tipvinext'], config('web-ldap-admin.replicado_unidade'), 1)[0]['total'];
+                            $countAD = count(App\Ldap\User::getUsersGroup($vinculo['tipvinext']));
+			                if ($countAD < $countReplicado) {
+			                    $styleColor = '#f00';
+                            } else {
+			                    $styleColor = '#000';
+                            }
+			            @endphp
                     <tr>
-                    <td><input type="checkbox" name="type[]" value="{{ $vinculo['tipvinext'] }}"></td>
+                        <td><input type="checkbox" name="type[]" value="{{ $vinculo['tipvinext'] }}"></td>
                         <td>{{ $vinculo['tipvinext'] }}</td>
                         <td style="text-align: right;">
-                            {{ Uspdev\Replicado\Pessoa::ativosVinculo($vinculo['tipvinext'], config('web-ldap-admin.replicado_unidade'), 1)[0]['total'] }}
-                        </td>
-                        <td style="text-align: right;">
-                            {{ count(App\Ldap\User::getUsersGroup($vinculo['tipvinext'])) }}
+                            {{ $countReplicado }}
+			            </td>
+                        <td style="text-align: right; color: {{ $styleColor }}">
+                            {{ $countAD }}
                         </td>
                     </tr>
-                    @endforeach                    
+                    @endforeach
                 </table>
 
                 <div class="form-group">


### PR DESCRIPTION
Fix #122

Abandonei a idea de Grupos x Unidades Organizacionais. Trabalhar com uma única Unidade Organizacional e poder aplicar GPO em Grupos de usuários é o melhor caminho.

Adicionada a variável LDAP_OU_DEFAULT no .env
Ignorando arquivos lando
Melhorando alguns itens do menu
Informando em vermelho quando ainda faltam contas a sincronizar