### PR TITLE
Prefixo no username quando o e-mail começa com dígito

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,8 +76,12 @@ REPLICADO_DATABASE=
 REPLICADO_USERNAME=
 REPLICADO_PASSWORD=
 
-# Em alguns métodos é necessário informar o código da unidade. Se houver mais de um código coloque eles separado por vrgulas.
+# Código da unidade
 REPLICADO_CODUNDCLG=
+
+# Todos os códigos de colegiados da unidade, separados por vírgula
+# (default=REPLICADO_CODUNDCLG)
+REPLICADO_CODUNDCLGS="${REPLICADO_CODUNDCLG}"
 
 # Se o SGBD é sybase ou versões mais novas do MSSQL use 1. Para versões mais antigas de MSSQL use 0 (default)
 REPLICADO_SYBASE=

--- a/.env.example
+++ b/.env.example
@@ -159,8 +159,10 @@ SINC_LDAP_LOGIN=1
 EXPIRAR_EM=0
 
 # Campo onde está o codpes para referência no replicado
-# Valores: employeeNumber, username (default)
+# Valores: employeeNumber ou username (default)
+# Quando employeeNumber o username será parte do e-mail sem @usp.br limitado a 15 caracteres
 CAMPO_CODPES=username
+# CAMPO_CODPES=employeeNumber
 
 # Tipo de senha gerada automaticamente, mas depende também da configuração de complexidade de senha do servidor AD
 # data_nascimento (default) - mas quando a pessoa não tem vinculo e pode logar e sincroniza no login, a conta é criada com senha random,
@@ -216,3 +218,7 @@ SYNC_GROUPS_WITH_REPLICADO=yes
 #   }
 # ]
 # CUR_HAB_SET=../storage/app/grCursoSetor.json
+
+# Apenas quando o e-mail começar com número
+# Não utilizar prefixo extenso
+PREFIX_USERNAME=

--- a/app/Http/Controllers/LdapUserController.php
+++ b/app/Http/Controllers/LdapUserController.php
@@ -131,7 +131,7 @@ class LdapUserController extends Controller
             'email' => ['required', 'email', new LdapEmailRule],
         ]);
 
-        $grupos = [$request->grupos, 'NAOREPLICADO'];
+        $grupos = array_merge($request->grupos, ['NAOREPLICADO']);
 
         LdapUser::createOrUpdate($request->username, [
                 'nome' => $request->nome,

--- a/app/Jobs/SincronizaReplicado.php
+++ b/app/Jobs/SincronizaReplicado.php
@@ -37,7 +37,7 @@ class SincronizaReplicado implements ShouldQueue
     public function handle()
     {
         foreach ($this->type as $type) {
-            foreach (Pessoa::tiposVinculos($this->unidade) as $vinculo) {
+            foreach (Pessoa::listarTiposVinculoExtenso() as $vinculo) {
                 if ($type == $vinculo['tipvinext']) {
                     $this->sync(Pessoa::ativosVinculo($vinculo['tipvinext'], $this->unidade));
                 }
@@ -64,7 +64,8 @@ class SincronizaReplicado implements ShouldQueue
                 // Array das pessoas do replicado
                 $replicadoUsers = [];
                 foreach ($pessoas as $pessoa) {
-                    array_push($replicadoUsers, $pessoa['codpes']);
+                    // se setado o prefixo passa prefixo + codpes
+                    array_push($replicadoUsers, config('web-ldap-admin.prefixUsername') . $pessoa['codpes']);
                 }
                 // Array das contas no AD
                 $contasAD = [];

--- a/app/Ldap/Group.php
+++ b/app/Ldap/Group.php
@@ -81,6 +81,7 @@ class Group
         // Nota: não encontrei nada que me permitisse distinguir grupo do default do sistema ou não
         // assim, por hora, vou assumir que os grupos criado pelo laravel estão sem descrição
         // adicionando iscriticalsystemobject como filtro. Melhora mas não limpa todos (Masaki)
+        // TODO 03/11/2022 - ECAdev @alecosta: Aqui na ECA (Windows Server 2019) lista os grupos DnsAdmins e DnsUpdateProxy
         $r = [];
         $groups = Adldap::search()->groups()->where('iscriticalsystemobject', '!', 'TRUE')->get();
         foreach ($groups as $group) {

--- a/app/Ldap/Group.php
+++ b/app/Ldap/Group.php
@@ -62,7 +62,10 @@ class Group
 
         foreach ($groups as $groupname) {
             $group = self::createOrUpdate($groupname);
-            $group->addMember($user);
+            // Somente se não pertence ao grupo
+            if (!$user->inGroup($groupname)) {
+                $group->addMember($user);
+            }
         }
     }
 

--- a/app/Ldap/Group.php
+++ b/app/Ldap/Group.php
@@ -62,8 +62,15 @@ class Group
 
         foreach ($groups as $groupname) {
             $group = self::createOrUpdate($groupname);
-            // Somente se não pertence ao grupo
-            if (!$user->inGroup($groupname)) {
+            // TODO 03/11/2022 - ECAdev @alecosta: Precisa ser compatível as unidades que utilizam: ECA, FFLCH, EESC, IF, ...
+            // 03/11/2022 - ECAdev @alecosta: Para que funcione na ECA, tenho que ignorar a condição abaixo. Com a condição os grupos são criados, mas o usuário não é adicionado nos grupos.
+            if (!in_array('27', explode(',', config('web-ldap-admin.replicado_unidades')))) {
+                // Somente se não pertence ao grupo
+                if (!$user->inGroup($groupname)) {
+                    $group->addMember($user);
+                }
+            } else {
+                // 03/11/2022 - ECAdev @alecosta: Na ECA adiciona no grupo independente de já pertencer ou não
                 $group->addMember($user);
             }
         }

--- a/app/Ldap/User.php
+++ b/app/Ldap/User.php
@@ -383,7 +383,7 @@ class User
                 break;
             case 'username':
             default:
-                $username = $pessoa['codpes'];
+                $username = $pessoa['codpes']; // TODO IF pretende usar com prefixo + username (codpes)
                 $attr['employeeNumber'] = '';
                 break;
         }

--- a/app/Ldap/User.php
+++ b/app/Ldap/User.php
@@ -12,7 +12,6 @@ use Uspdev\Replicado\Estrutura;
 use Uspdev\Replicado\Pessoa;
 use Uspdev\Utils\Generic as Utils;
 use \Adldap\Models\User as LdapUser;
-use App\Replicado\Pessoa;
 
 class User
 {
@@ -436,7 +435,7 @@ class User
 
         if( $pessoa['tipvinext'] != 'Externo') {
             if(config('web-ldap-admin.tipoNomesGrupos') == 'extenso'){
-                $vinculosSetores = Pessoa::listarVinculosSetores($pessoa['codpes'], config('web-ldap-admin.replicado_unidade'));
+                $vinculosSetores = \App\Replicado\Pessoa::listarVinculosExtensoSetores($pessoa['codpes'], config('web-ldap-admin.replicado_unidade'));
                 foreach ($vinculosSetores as $key => $value) {
                     if ($value == 'Aluno de Graduação' && isset($nomabvset)) {
                         $vinculosSetores[1] = 'Aluno de Graduação ' . $nomabvset;

--- a/app/Ldap/User.php
+++ b/app/Ldap/User.php
@@ -249,6 +249,18 @@ class User
                 }
                 break;
             case 'username':
+                if (config('web-ldap-admin.prefixUsername') != '') {
+                    if (!is_numeric($codpes = $user->getEmployeeNumber())) {
+                        $codpes = $user->getAccountName();
+                        $valido = false;
+                    }
+                } else {
+                    if (!is_numeric($codpes = $user->getAccountName())) {
+                        $codpes = $user->getEmployeeNumber();
+                        $valido = false;
+                    }
+                }
+                break;
             default:
                 if (!is_numeric($codpes = $user->getAccountName())) {
                     $codpes = $user->getEmployeeNumber();

--- a/app/Ldap/User.php
+++ b/app/Ldap/User.php
@@ -12,6 +12,7 @@ use Uspdev\Replicado\Estrutura;
 use Uspdev\Replicado\Pessoa;
 use Uspdev\Utils\Generic as Utils;
 use \Adldap\Models\User as LdapUser;
+use App\Replicado\Pessoa;
 
 class User
 {
@@ -435,7 +436,7 @@ class User
 
         if( $pessoa['tipvinext'] != 'Externo') {
             if(config('web-ldap-admin.tipoNomesGrupos') == 'extenso'){
-                $vinculosSetores = Pessoa::vinculosSetores($pessoa['codpes'], config('web-ldap-admin.replicado_unidade'));
+                $vinculosSetores = Pessoa::listarVinculosSetores($pessoa['codpes'], config('web-ldap-admin.replicado_unidade'));
                 foreach ($vinculosSetores as $key => $value) {
                     if ($value == 'Aluno de Graduação' && isset($nomabvset)) {
                         $vinculosSetores[1] = 'Aluno de Graduação ' . $nomabvset;

--- a/app/Ldap/User.php
+++ b/app/Ldap/User.php
@@ -51,7 +51,7 @@ class User
             // Enable the new user (using user account control).
             $user->setUserAccountControl(AccountControl::NORMAL_ACCOUNT);
 
-            // vamos expirar senha conforme config
+            // vamos expirar senha conforme configsobrenome
             $user->setAccountExpiry(SELF::getExpiryDays());
         }
 
@@ -78,6 +78,11 @@ class User
         // caso o codpes venha no employeenumber
         if (!empty($attr['employeeNumber'])) {
             $user->setEmployeeNumber($attr['employeeNumber']);
+        }
+
+        // caso o codpes venha no physicaldeliveryofficename
+        if (!empty($attr['physicalDeliveryOfficeName'])) {
+            $user->setPhysicalDeliveryOfficeName($attr['physicalDeliveryOfficeName']);
         }
 
         // Departamento
@@ -340,9 +345,7 @@ class User
             // remover dos grupos
             $user = SELF::obterUserPorUsername($desligado);
             $groups = $user->getGroups();
-            dd($groups);
             foreach ($groups as $group) {
-                echo "{$desligado}: <br />";
                 $group->removeMember($user);
             }
 
@@ -369,8 +372,14 @@ class User
             case 'employeenumber':
                 $username = explode('@', $pessoa['codema'])[0];
                 $username = preg_replace("/[^a-zA-Z0-9]+/", "", $username); //email sem caracteres especiais
-                $username = substr($username, 0, 15); //limitando em 15 caracteres
+                // Se username inicia com número o prefixo é adicionado
+                if (is_numeric(substr($username, 0, 1))) {
+                    $username = config('web-ldap-admin.prefixUsername') . substr($username, 0, (15 - strlen(config('web-ldap-admin.prefixUsername')))); //limitando em 15 caracteres
+                } else {
+                    $username = substr($username, 0, 15); //limitando em 15 caracteres
+                }
                 $attr['employeeNumber'] = $pessoa['codpes'];
+                $attr['physicalDeliveryOfficeName'] = $pessoa['codpes'];
                 break;
             case 'username':
             default:

--- a/app/Ldap/User.php
+++ b/app/Ldap/User.php
@@ -384,6 +384,7 @@ class User
             case 'username':
             default:
                 $username = $pessoa['codpes']; // TODO IF pretende usar com prefixo + username (codpes)
+                $attr['physicalDeliveryOfficeName'] = $pessoa['codpes']; # por padrão gravar o codpes na coluna Office do MS AD // TODO quem usa Samba precisa testar
                 $attr['employeeNumber'] = '';
                 break;
         }

--- a/app/Ldap/User.php
+++ b/app/Ldap/User.php
@@ -157,7 +157,8 @@ class User
 
         // não vai encontrar se for pelo username, nesse caso vamos usar o CN
         if (is_null($user)) {
-            $user = Adldap::search()->users()->where('cn', '=', $codpes)->first();
+            // se estiver usando o prefixo
+            $user = Adldap::search()->users()->where('cn', '=', config('web-ldap-admin.prefixUsername') . $codpes)->first();
         }
 
         return $user;
@@ -382,8 +383,16 @@ class User
                 $attr['physicalDeliveryOfficeName'] = $pessoa['codpes'];
                 break;
             case 'username':
+                $username = config('web-ldap-admin.prefixUsername') . $pessoa['codpes'];
+                if (config('web-ldap-admin.prefixUsername') != '') {
+                    $attr['employeeNumber'] = $pessoa['codpes'];
+                } else {
+                    $attr['employeeNumber'] = '';
+                }
+                $attr['physicalDeliveryOfficeName'] = $pessoa['codpes'];
+                break;
             default:
-                $username = $pessoa['codpes']; // TODO IF pretende usar com prefixo + username (codpes)
+                $username = $pessoa['codpes'];
                 $attr['physicalDeliveryOfficeName'] = $pessoa['codpes']; # por padrão gravar o codpes na coluna Office do MS AD // TODO quem usa Samba precisa testar
                 $attr['employeeNumber'] = '';
                 break;

--- a/app/Listeners/LoginListener.php
+++ b/app/Listeners/LoginListener.php
@@ -7,7 +7,6 @@ use App\Models\Config;
 use Illuminate\Auth\Events\Login;
 use Session;
 use Uspdev\Replicado\Pessoa;
-use App\Replicado\Pessoa;
 
 class LoginListener
 {
@@ -34,7 +33,7 @@ class LoginListener
         $event->user->username = $event->user->codpes;
         $event->user->save();
 
-        $vinculos = Pessoa::listarVinculosSetores($event->user->username, config('web-ldap-admin.replicado_unidade'));
+        $vinculos = \App\Replicado\Pessoa::listarVinculosExtensoSetores($event->user->username, config('web-ldap-admin.replicado_unidade'));
 
         // Como usamos a função array_merge, as respostas nulas devem ser arrays vazios
         if ($vinculos == null) {

--- a/app/Listeners/LoginListener.php
+++ b/app/Listeners/LoginListener.php
@@ -7,6 +7,7 @@ use App\Models\Config;
 use Illuminate\Auth\Events\Login;
 use Session;
 use Uspdev\Replicado\Pessoa;
+use App\Replicado\Pessoa;
 
 class LoginListener
 {
@@ -33,7 +34,7 @@ class LoginListener
         $event->user->username = $event->user->codpes;
         $event->user->save();
 
-        $vinculos = Pessoa::vinculosSetores($event->user->username, config('web-ldap-admin.replicado_unidade'));
+        $vinculos = Pessoa::listarVinculosSetores($event->user->username, config('web-ldap-admin.replicado_unidade'));
 
         // Como usamos a função array_merge, as respostas nulas devem ser arrays vazios
         if ($vinculos == null) {

--- a/app/Replicado/Pessoa.php
+++ b/app/Replicado/Pessoa.php
@@ -20,4 +20,64 @@ class Pessoa extends ReplicadoPessoa
         $param['codpes'] = $codpes;
         return DB::fetch($sql, $param);
     }
+
+    /**
+     * Método para listar todos os vínculos e setores de uma pessoa
+     *
+     * Somente ATIVOS
+     * Também Docente Aposentado
+     *
+     * @param Integer $codpes
+     * @param (opt) $codundclg (default=null)
+     * @return array
+     * @author modificado por Alessandro em 10/11/2022
+     */
+    public static function listarVinculosSetores(int $codpes, $codundclg = null) # codundclg não pode ser Integer por conta de mais de uma unidade
+    {
+        $codundclg = $codundclg ?: getenv('REPLICADO_CODUNDCLGS');
+        $codundclg = $codundclg ?: getenv('REPLICADO_CODUNDCLG');
+
+        // Array com os códigos de unidades
+        $arrCodUnidades = explode(',', $codundclg);
+
+        // Somente os vínculos regulares 'ALUNOGR', 'ALUNOPOS', 'ALUNOCEU', 'ALUNOEAD', 'ALUNOPD', 'ALUNOCONVENIOINT', 'SERVIDOR', 'ESTAGIARIORH'
+        // Considerando mais de uma unidade, ex.: 84 = Alunos de Pós-Graduação Interunidades
+        $query = "SELECT * FROM LOCALIZAPESSOA WHERE codpes = CONVERT(INT, :codpes)
+                 AND codfncetr = 0 --exclui designados
+                 AND tipvinext != 'Servidor Aposentado' --exclui funcionários não docentes aposentados
+                 AND tipvin IN ('ALUNOGR', 'ALUNOPOS', 'ALUNOCEU', 'ALUNOEAD', 'ALUNOPD', 'ALUNOCONVENIOINT', 'SERVIDOR', 'ESTAGIARIORH')
+                 AND codundclg IN ({$codundclg})";
+        $param['codpes'] = $codpes;
+        $result = DB::fetchAll($query, $param);
+
+        // Inicializa o array de vínculos e setores
+        $vinculosSetores = array();
+        foreach ($result as $row) {
+            if (!empty($row['tipvinext'])) {
+                $vinculo = trim($row['tipvinext']);
+                // Adiciona os vínculos por extenso
+                array_push($vinculosSetores, $vinculo);
+                // Adiciona o departamento quando também for Aluno de Graduação
+                if (trim($row['tipvinext']) == 'Aluno de Graduação') {
+                    // Considerando o primeiro código de unidade
+                    $setorGraduacao = Graduacao::setorAluno($row['codpes'], $arrCodUnidades[0])['nomabvset'];
+                    array_push($vinculosSetores, $row['tipvinext'] . ' ' . $setorGraduacao);
+                }
+            }
+            if (!empty(trim($row['nomabvset']))) {
+                $setor = trim($row['nomabvset']);
+                // Remove o código da unidade da sigla do setor
+                // Considerando o primeiro código de unidade
+                $setor = str_replace('-' . $arrCodUnidades[0], '', $setor);
+                // Adiciona as siglas dos setores
+                array_push($vinculosSetores, $setor);
+                // Adiciona os vínculos por extenso concatenando a sigla do setor
+                array_push($vinculosSetores, $row['tipvinext'] . ' ' . $setor);
+            }
+        }
+        $vinculosSetores = array_unique($vinculosSetores);
+        sort($vinculosSetores);
+        return $vinculosSetores;
+    }
+
 }

--- a/app/Replicado/Pessoa.php
+++ b/app/Replicado/Pessoa.php
@@ -22,7 +22,7 @@ class Pessoa extends ReplicadoPessoa
     }
 
     /**
-     * Método para listar todos os vínculos e setores de uma pessoa
+     * Método para listar todos os vínculos por extenso e setores de uma pessoa
      *
      * Somente ATIVOS
      * Também Docente Aposentado
@@ -32,7 +32,7 @@ class Pessoa extends ReplicadoPessoa
      * @return array
      * @author modificado por Alessandro em 10/11/2022
      */
-    public static function listarVinculosSetores(int $codpes, $codundclg = null) # codundclg não pode ser Integer por conta de mais de uma unidade
+    public static function listarVinculosExtensoSetores(int $codpes, $codundclg = null) # codundclg não pode ser Integer por conta de mais de uma unidade
     {
         $codundclg = $codundclg ?: getenv('REPLICADO_CODUNDCLGS');
         $codundclg = $codundclg ?: getenv('REPLICADO_CODUNDCLG');

--- a/app/Replicado/Pessoa.php
+++ b/app/Replicado/Pessoa.php
@@ -4,6 +4,7 @@ namespace App\Replicado;
 
 use Uspdev\Replicado\DB;
 use Uspdev\Replicado\Pessoa as ReplicadoPessoa;
+use Uspdev\Replicado\Graduacao;
 
 class Pessoa extends ReplicadoPessoa
 {

--- a/composer.lock
+++ b/composer.lock
@@ -6298,11 +6298,11 @@
         },
         {
             "name": "uspdev/replicado",
-            "version": "1.13.2",
+            "version": "1.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/uspdev/replicado.git",
-                "reference": "b6d1dcf685c42d6d328e85b623dcc49da24219d4"
+                "reference": "440312a8d28bdefe64be57e49fa5b6b37fa3ddb3"
             },
             "require": {
                 "ext-pdo_dblib": "*",
@@ -6338,7 +6338,7 @@
             ],
             "description": "Classes PHP que consome dados do Replicado USP",
             "homepage": "https://github.com/uspdev/replicado",
-            "time": "2022-06-10T00:46:59+00:00"
+            "time": "2022-11-09T19:48:14+00:00"
         },
         {
             "name": "uspdev/senhaunica-socialite",
@@ -8960,5 +8960,5 @@
         "php": "^7.2.5"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/config/web-ldap-admin.php
+++ b/config/web-ldap-admin.php
@@ -6,6 +6,7 @@ return [
 
     # Unidades autorizadas
     'replicado_unidade' => env('REPLICADO_CODUNDCLG'),
+    'replicado_unidades' => env('REPLICADO_CODUNDCLGS'),
 
     # Paginação, quantidade de registros padrão, 50 default
     'registrosPorPagina' => env('REGISTROS_POR_PAGINA', 50),

--- a/config/web-ldap-admin.php
+++ b/config/web-ldap-admin.php
@@ -43,7 +43,7 @@ return [
     'ocultarUsuarios' => ['administrator', 'administrador', 'krbtgt', 'guest'],
 
     # Campo LDAP que será usado como codpes
-    # username, employeeNumber, physicalDeliveryOfficeName
+    # username ou employeeNumber
     # vai ser aplicado strtolower então o case não importa
     'campoCodpes' => env('CAMPO_CODPES','username'),
 

--- a/config/web-ldap-admin.php
+++ b/config/web-ldap-admin.php
@@ -43,7 +43,7 @@ return [
     'ocultarUsuarios' => ['administrator', 'administrador', 'krbtgt', 'guest'],
 
     # Campo LDAP que será usado como codpes
-    # username, employeeNumber
+    # username, employeeNumber, physicalDeliveryOfficeName
     # vai ser aplicado strtolower então o case não importa
     'campoCodpes' => env('CAMPO_CODPES','username'),
 
@@ -72,4 +72,7 @@ return [
 
     # 0 não mostra foto (nem foto fake), 1 mostra foto
     'mostrarFoto' => env('MOSTRAR_FOTO', 0),
+
+    # Prefixo do username
+    'prefixUsername' => env('PREFIX_USERNAME', ''),
 ];


### PR DESCRIPTION
Fix #148 

Quando CAMPO_CODPES=employeeNumber e o e-mail começar com dígito, o prefixo PREFIX_USERNAME= é adicionado no início do username.

Exemplo:
 
CAMPO_CODPES=employeeNumber
PREFIX_USERNAME=x

Fulano de Tal, e-mail 777fulano.tal@usp.br, o username será x777fulanotal