### PR TITLE
corrigindo a exibição dos nomes dos computadores.

### DIFF
--- a/app/Http/Controllers/LdapUserController.php
+++ b/app/Http/Controllers/LdapUserController.php
@@ -410,4 +410,20 @@ class LdapUserController extends Controller
     $request->session()->flash('alert-success', 'Grupo(s) adicionado(s) com sucesso.');
     return redirect("/ldapusers/$request->username");
   }
+
+  public function deleteUserGroup(Request $request, $username, $group)
+  {
+    $this->authorize('manager');
+
+    $user = LdapUser::obterUserPorUsername($username);
+    $group = Group::where('cn', '=', $group)->first();
+
+    if ( $user->groups()->exists($group) ) {
+        $user->groups()->detach($group);
+        $request->session()->flash('alert-success', 'Grupo ' . $group['name'][0] . ' removido com sucesso.');
+    }
+
+    return redirect()->back();
+  }
+
 }

--- a/app/Http/Controllers/SolicitaController.php
+++ b/app/Http/Controllers/SolicitaController.php
@@ -40,7 +40,7 @@ class SolicitaController extends Controller
 
                 if ($carbon->diffInDays(Carbon::now()) < 120) {
                     array_push($computers, [
-                        'computer' => $computer->getFirstAttribute('cn'),
+                        'computer' => $computer->getFirstAttribute('name'),
                         'os' => $os,
                         'lastLogon' => $carbon->format('d/m/Y H:i:s')
                     ]);

--- a/app/Ldap/User.php
+++ b/app/Ldap/User.php
@@ -266,7 +266,7 @@ class User
     // Grupos: vamos ocultar o grupo "Domain Users"
     $grupos = array_diff($user->groups()->get()->pluck('cn')->flatten()->toArray(), ['Domain Users']);
     sort($grupos);
-    $attr['grupos'] = implode(', ', $grupos);
+    $attr['grupos'] = $grupos;
 
     // Department
     $attr['department'] = $user->getFirstAttribute('department');

--- a/resources/views/ldapusers/partials/add-group-form.blade.php
+++ b/resources/views/ldapusers/partials/add-group-form.blade.php
@@ -15,7 +15,7 @@
                     <label for="grupos">Selecione o(s) grupo(s) ou digite o(s) nome(s) de novo(s) grupo(s)</label>
                     <select class="select2 form-control" id="grupos" name="grupos[]" multiple="multiple" required>
                         @foreach (\App\Ldap\Group::listaGrupos() as $grupo)
-                            @if (!in_array($grupo, explode(', ', $attr['grupos'])))
+                            @if (!in_array($grupo, $attr['grupos']))
                                 <option value="{{ $grupo }}">{{ $grupo }}</option>
                             @endif
                         @endforeach

--- a/resources/views/ldapusers/partials/show-basic.blade.php
+++ b/resources/views/ldapusers/partials/show-basic.blade.php
@@ -12,7 +12,21 @@
     <tr>
       <td> <b> Grupos </b> </td>
       <td>
-        {{ $attr['grupos'] ?? '' }}
+        @foreach ($attr['grupos'] as $group)
+          {{ $group }}
+          <form action="ldapusers/{{ $attr['username'] }}/{{ $group }}" method="post" style="display: inline-block">
+            @csrf
+            @method('delete')
+            <button
+              class="btn btn-sm btn-danger delete-item mb-1"
+              type="submit"
+              data-toggle="tooltip"
+              data-placement="top"
+              title="Excluir grupo {{ $group }} do usuário">
+              <i class="fas fa-trash-alt"></i>
+            </button>
+          </form>
+        @endforeach
         @can('manager')
         <button type="button" class="btn btn-success btn-sm ml-2" data-toggle="modal" data-target="#addGroup" data-backdrop="static"
           data-whatever="{{ $attr['username'] }} {{ $attr['display_name'] }}" data-keyboard="false" title="Adicionar ao(s) grupo(s)">

--- a/resources/views/solicita/create.blade.php
+++ b/resources/views/solicita/create.blade.php
@@ -44,7 +44,7 @@
 
                     <div class="form-group">
                         <label for="computer">Em computador deseja a liberação de acesso administrativo?</label>
-                        <select name="computer" class="form-control">
+                        <select name="computer" class="form-select select2">
                             <option value="" selected="">-- Selecione --</option>
                             @foreach($computers as $computer)
                                 <option value="{{ $computer['computer'] }}">
@@ -62,4 +62,12 @@
         </div>
     </div>
 
+@stop
+
+@section('javascripts_bottom')
+<script>
+  $(document).ready(function() {
+    $('.select2').select2();
+  });
+</script>
 @stop

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,6 +18,7 @@ Route::patch('ldapusers/{username}', [LdapUserController::class, 'update']);
 Route::get('ldapusers/{username}', [LdapUserController::class, 'show']);
 Route::delete('ldapusers/{username}', [LdapUserController::class, 'destroy']);
 Route::post('ldapusers/group', [LdapUserController::class, 'addGroup']);
+Route::delete('ldapusers/{username}/{group}', [LdapUserController::class, 'deleteUserGroup']);
 
 #configs
 Route::get('configs', [ConfigController::class, 'show']);


### PR DESCRIPTION
    Após a mudança para biblioteca directorytree/ldaprecord-laravel os
    nomes dos computadores não estavam aparecendo ao solicitar a administração do mesmo.
    Foi aplicado no select dos computadores o uso do select2 para
    facilitar a busca dos mesmos.